### PR TITLE
Upgrade to VMWare Horizon 5.0.0 and add Gnome theme support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL version="0.1.2"
 # Update this URL as necessary. One day I might work this into the script.
 # Run the following command to find the latest URL:
 # $ curl -s "https://my.vmware.com/web/vmware/details?downloadGroup=CART18FQ4_LIN64_470&productId=578&rPId=20573" | grep -o '<a href="http[^"]*.x64.bundle"' | sed 's/<a href="//;s/"$//'
-ENV URL https://download3.vmware.com/software/view/viewclients/CART18FQ4/VMware-Horizon-Client-4.7.0-7395152.x64.bundle
+ENV URL https://download3.vmware.com/software/view/viewclients/CART20FQ1/VMware-Horizon-Client-5.0.0-12557422.x64.bundle
 
 # To run the container:
 # $ xhost local:docker

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Nice for when you don't want your host to have all the dependencies installed,
 or you'd like some isolation between the VMware binary and the rest of
 your machine.
 
+While this container will run the client as root by default, using [Podman](https://podman.io/),
+it can be run as any user easily.
+
 ## VMware View Configuration
 
 There are two files related to the VMware Horizon Client configuration. They
@@ -38,6 +41,76 @@ To run the container from the prebuilt image on [Docker Hub](https://hub.docker.
             -e DISPLAY=$DISPLAY \
             --device /dev/snd \
             exotime/vmware-horizon-docker
+```
+
+## GTK/Gnome Theme Support
+Normally, the container will not have access to your Gnome themes, icons, etc.
+However, these can be mounted into the container and the client will use them just fine.
+The `run-gnome.sh` script includes a way to detect the themes configured on the
+running dconf based desktop and mount them into the container:
+
+```shell
+IMAGE_NAME=${IMAGE_NAME:-exotime/vmware-horizon-docker}
+
+if [[ "${XDG_SESSION_DESKTOP}" = "deepin" ]]; then
+    ICON_THEME=$(gsettings get com.deepin.dde.appearance icon-theme | tr -d "'")
+    GTK_THEME=$(gsettings get com.deepin.dde.appearance gtk-theme | tr -d "'")
+    CURSOR_THEME=$(gsettings get com.deepin.dde.appearance cursor-theme | tr -d "'")
+else
+    ICON_THEME=$(gsettings get org.gnome.desktop.interface icon-theme | tr -d "'")
+    GTK_THEME=$(gsettings get org.gnome.desktop.interface gtk-theme | tr -d "'")
+    CURSOR_THEME=$(gsettings get org.gnome.desktop.interface cursor-theme | tr -d "'")
+fi
+
+if [[ ! "${CURSOR_THEME}" = "${ICON_THEME}" ]]; then
+    if [[ -d "${HOME}/.icons/${CURSOR_THEME}" ]]; then
+        CURSOR_THEME="-v ${HOME}/.icons/${CURSOR_THEME}:/usr/share/icons/${CURSOR_THEME}:ro"
+    elif [[ -d "${HOME}/.local/share/icons/${CURSOR_THEME}" ]]; then
+        CURSOR_THEME="-v ${HOME}/.local/share/icons/${CURSOR_THEME}:/usr/share/icons/${CURSOR_THEME}:ro"
+    elif [[ -d "/usr/share/icons/${CURSOR_THEME}" ]]; then
+        CURSOR_THEME="-v /usr/share/icons/${CURSOR_THEME}:/usr/share/icons/${CURSOR_THEME}:ro"
+    else
+        CURSOR_THEME=""
+    fi
+else
+    CURSOR_THEME=""
+fi
+
+if [[ -d "${HOME}/.icons/${ICON_THEME}" ]]; then
+    ICON_THEME="-v ${HOME}/.icons/${ICON_THEME}:/usr/share/icons/${ICON_THEME}:ro"
+elif [[ -d "${HOME}/.local/share/icons/${ICON_THEME}" ]]; then
+    ICON_THEME="-v ${HOME}/.local/share/icons/${ICON_THEME}:/usr/share/icons/${ICON_THEME}:ro"
+elif [[ -d "/usr/share/icons/${ICON_THEME}" ]]; then
+    ICON_THEME="-v /usr/share/icons/${ICON_THEME}:/usr/share/icons/${ICON_THEME}:ro"
+else
+    ICON_THEME=""
+fi
+
+if [[ -d "${HOME}/.themes/${GTK_THEME}" ]]; then
+    GTK_THEME="-v ${HOME}/.themes/${GTK_THEME}:/usr/share/themes/${GTK_THEME}:ro"
+elif [[ -d "${HOME}/.local/share/themes/${GTK_THEME}" ]]; then
+    GTK_THEME="-v ${HOME}/.local/share/themes/${GTK_THEME}:/usr/share/themes/${GTK_THEME}:ro"
+elif [[ -d "/usr/share/themes/${GTK_THEME}" ]]; then
+    GTK_THEME="-v /usr/share/themes/${GTK_THEME}:/usr/share/themes/${GTK_THEME}:ro"
+else
+    GTK_THEME=""
+fi
+
+GTK_ENGINES=""
+for ENGINE64 in $(find /usr/lib64/gtk*/*/engines -iname '*.so'); do
+    GTK_ENGINES="${GTK_ENGINES} -v ${ENGINE64}:/usr/lib/x86_64-linux-gnu/$(echo ${ENGINE64} | sed 's|/usr/lib64/||'):ro"
+done
+
+docker run --rm -it \
+            --privileged \
+            -v /tmp/.X11-unix:/tmp/.X11-unix \
+            -v ${HOME}/.vmware:/root/.vmware/ \
+            -v /etc/localtime:/etc/localtime:ro \
+            -v /dev/bus/usb:/dev/bus/usb \
+            -v ${HOME}:/home/$(whoami) \
+            -e DISPLAY=$DISPLAY \
+            --device /dev/snd \
+            ${ICON_THEME} ${GTK_THEME} ${CURSOR_THEME} ${GTK_ENGINES} ${IMAGE_NAME}
 ```
 
 ## How to build it for yourself:

--- a/run-gnome.sh
+++ b/run-gnome.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# This script will launch the VMWare Horizon Client via Docker and has
+# been tested on Fedora 30 with the Deepin desktop. It should, in theory
+# work for Gnome too as well as others that use the same gsettings keys.
+#
+# It should also work for those that don't, but you won't get theme
+# support.
+#
+# THIS WILL RUN VMWARE VIEW AS ROOT WHICH IS A TERRIBLE IDEA. SORRY.
+# Someone may be able to work around this by tweaking the container
+# and passing `--user` to Docker but...
+#
+# This was tested with Podman, which won't run it as root, by the way.
+set -e
+IMAGE_NAME=${IMAGE_NAME:-exotime/vmware-horizon-docker}
+
+if [[ "${1}" = "check-image" ]] ; then
+    [[ -z "$(docker images -q -f "reference=${IMAGE_NAME}" 2>/dev/null)" ]]
+elif [[ "${1}" = "pull-only" ]] ; then
+    docker pull ${IMAGE_NAME}
+else
+    if [[ "${XDG_SESSION_DESKTOP}" = "deepin" ]]; then
+        ICON_THEME=$(gsettings get com.deepin.dde.appearance icon-theme | tr -d "'")
+        GTK_THEME=$(gsettings get com.deepin.dde.appearance gtk-theme | tr -d "'")
+        CURSOR_THEME=$(gsettings get com.deepin.dde.appearance cursor-theme | tr -d "'")
+    else
+        ICON_THEME=$(gsettings get org.gnome.desktop.interface icon-theme | tr -d "'")
+        GTK_THEME=$(gsettings get org.gnome.desktop.interface gtk-theme | tr -d "'")
+        CURSOR_THEME=$(gsettings get org.gnome.desktop.interface cursor-theme | tr -d "'")
+    fi
+
+    if [[ ! "${CURSOR_THEME}" = "${ICON_THEME}" ]]; then
+        if [[ -d "${HOME}/.icons/${CURSOR_THEME}" ]]; then
+            CURSOR_THEME="-v ${HOME}/.icons/${CURSOR_THEME}:/usr/share/icons/${CURSOR_THEME}:ro"
+        elif [[ -d "${HOME}/.local/share/icons/${CURSOR_THEME}" ]]; then
+            CURSOR_THEME="-v ${HOME}/.local/share/icons/${CURSOR_THEME}:/usr/share/icons/${CURSOR_THEME}:ro"
+        elif [[ -d "/usr/share/icons/${CURSOR_THEME}" ]]; then
+            CURSOR_THEME="-v /usr/share/icons/${CURSOR_THEME}:/usr/share/icons/${CURSOR_THEME}:ro"
+        else
+            CURSOR_THEME=""
+        fi
+    else
+        CURSOR_THEME=""
+    fi
+
+    if [[ -d "${HOME}/.icons/${ICON_THEME}" ]]; then
+        ICON_THEME="-v ${HOME}/.icons/${ICON_THEME}:/usr/share/icons/${ICON_THEME}:ro"
+    elif [[ -d "${HOME}/.local/share/icons/${ICON_THEME}" ]]; then
+        ICON_THEME="-v ${HOME}/.local/share/icons/${ICON_THEME}:/usr/share/icons/${ICON_THEME}:ro"
+    elif [[ -d "/usr/share/icons/${ICON_THEME}" ]]; then
+        ICON_THEME="-v /usr/share/icons/${ICON_THEME}:/usr/share/icons/${ICON_THEME}:ro"
+    else
+        ICON_THEME=""
+    fi
+
+    if [[ -d "${HOME}/.themes/${GTK_THEME}" ]]; then
+        GTK_THEME="-v ${HOME}/.themes/${GTK_THEME}:/usr/share/themes/${GTK_THEME}:ro"
+    elif [[ -d "${HOME}/.local/share/themes/${GTK_THEME}" ]]; then
+        GTK_THEME="-v ${HOME}/.local/share/themes/${GTK_THEME}:/usr/share/themes/${GTK_THEME}:ro"
+    elif [[ -d "/usr/share/themes/${GTK_THEME}" ]]; then
+        GTK_THEME="-v /usr/share/themes/${GTK_THEME}:/usr/share/themes/${GTK_THEME}:ro"
+    else
+        GTK_THEME=""
+    fi
+
+    GTK_ENGINES=""
+    for ENGINE64 in $(find /usr/lib64/gtk*/*/engines -iname '*.so'); do
+        GTK_ENGINES="${GTK_ENGINES} -v ${ENGINE64}:/usr/lib/x86_64-linux-gnu/$(echo ${ENGINE64} | sed 's|/usr/lib64/||'):ro"
+    done
+
+    docker run --rm -it \
+                --privileged \
+                -v /tmp/.X11-unix:/tmp/.X11-unix \
+                -v ${HOME}/.vmware:/root/.vmware/ \
+                -v /etc/localtime:/etc/localtime:ro \
+                -v /dev/bus/usb:/dev/bus/usb \
+                -v ${HOME}:/home/$(whoami) \
+                -e DISPLAY=$DISPLAY \
+                --device /dev/snd \
+                ${ICON_THEME} ${GTK_THEME} ${CURSOR_THEME} ${GTK_ENGINES} ${IMAGE_NAME}
+fi


### PR DESCRIPTION
Upgrade the internal container to 5.0.0 which fixes black screens, improves performance, and other various things.

Also, add a script and some documentation for how to integrate the client better into a desktop by add themes, fonts, icons, etc. as volume mounts and the user's home directory for sharing with the VDI desktop.