### PR TITLE
Update VMWare horizon client to 8.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.source https://github.com/exotime/vmware-horizon-
 # Update this URL as necessary. One day I might work this into the script.
 # Run the following command to find the latest URL:
 # $ curl -s "https://my.vmware.com/web/vmware/details?downloadGroup=CART20FQ2_LIN64_510&productId=863&rPId=34529" | grep -o '<a href="http[^"]*.x64.bundle"' | sed 's/<a href="//;s/"$//'
-ENV URL https://download3.omnissa.com/software/CART25FQ1_LIN64_2312.1/VMware-Horizon-Client-2312.1-8.12.1-23543969.x64.bundle
+ENV URL https://download3.omnissa.com/software/CART25FQ2_LIN64_2406/VMware-Horizon-Client-2406-8.13.0-9995429239.x64.bundle
 
 # To run the container:
 # $ xhost local:docker


### PR DESCRIPTION
Just an URL update for the latest VMWare horizon client version.